### PR TITLE
Avoid hidden failures when dumping

### DIFF
--- a/pgclone/dump_cmd.py
+++ b/pgclone/dump_cmd.py
@@ -42,7 +42,7 @@ def _dump(*, exclude, config, pre_dump_hooks, instance, database, storage_locati
         [f"--exclude-table-data={table_name}" for table_name in exclude_tables]
     )
     # Note - do note format {db_dump_url} with an `f` string.
-    # It will be formatted later when running the command
+    # It will be formatted later when running the command.
     pg_dump_cmd_fmt = "pg_dump -Fc --no-acl --no-owner {db_dump_url} " + exclude_args
     pg_dump_cmd_fmt += " " + storage_client.pg_dump(file_path)
 
@@ -50,7 +50,7 @@ def _dump(*, exclude, config, pre_dump_hooks, instance, database, storage_locati
     logging.success_msg(f"Creating DB copy with cmd: {anon_pg_dump_cmd}")
 
     pg_dump_cmd = pg_dump_cmd_fmt.format(db_dump_url=db.url(dump_db))
-    run.shell(pg_dump_cmd, env=storage_client.env)
+    run.shell(pg_dump_cmd, env=storage_client.env, pipefail=True)
 
     logging.success_msg(f'Database "{database}" successfully dumped to "{dump_key}"')
 

--- a/pgclone/run.py
+++ b/pgclone/run.py
@@ -5,6 +5,7 @@ import io
 import os
 import subprocess
 import sys
+from typing import Any
 
 from django.core.management import call_command
 

--- a/pgclone/run.py
+++ b/pgclone/run.py
@@ -11,7 +11,7 @@ from pgclone import exceptions, logging
 
 def _is_pipefail_supported() -> bool:
     """Check if the current shell supports pipefail."""
-    if sys.platform == "win32":
+    if sys.platform == "win32":  # pragma: no cover
         return False
 
     try:

--- a/pgclone/run.py
+++ b/pgclone/run.py
@@ -36,7 +36,7 @@ def shell(
     is raised if it fails.
     """
     if pipefail and _is_pipefail_supported():  # pragma: no cover
-        cmd = [f"set -o pipefail; {cmd}"]
+        cmd = f"set -o pipefail; {cmd}"
 
     env = env or {}
     logger = logging.get_logger()

--- a/pgclone/tests/test_run.py
+++ b/pgclone/tests/test_run.py
@@ -1,0 +1,16 @@
+import subprocess
+from unittest.mock import patch
+
+from pgclone import run
+
+
+def test_is_pipefail_supported():
+    with patch("subprocess.check_call", autospec=True, return_value=0):
+        assert run._is_pipefail_supported() is True
+
+    with patch(
+        "subprocess.check_call",
+        side_effect=subprocess.CalledProcessError(1, "cmd"),
+        autospec=True,
+    ):
+        assert run._is_pipefail_supported() is False


### PR DESCRIPTION
I recently ran into an issue where we were getting silent failures despite `pg_dump` failing. In particular had a client/server mismatch (client had a version of 16, with the server being on 17) - resulting in us creating empty dumps on S3. 

This PR sets pipefail when dumping to ensure capture failures in `pg_dump`. Currently none of the integration tests interact with S3, but if we want something I'm happy to add something mocking out the storage layer to simulate piping even when dumping locally.