### PR TITLE
Use `SHELL` To Execute

### DIFF
--- a/pgclone/run.py
+++ b/pgclone/run.py
@@ -35,8 +35,13 @@ def shell(
     Utility for running a command. Ensures that an error
     is raised if it fails.
     """
+    executable: str | None = None
     if pipefail and _is_pipefail_supported():  # pragma: no cover
         cmd = f"set -o pipefail; {cmd}"
+        # If requested and supported by the user's shell, enable pipefail and
+        # execute using that shell rather than the system default /bin/sh to 
+        # ensure the pipefail is supported.
+        executable = os.environ.get("SHELL", "/bin/sh")
 
     env = env or {}
     logger = logging.get_logger()
@@ -45,6 +50,7 @@ def shell(
         shell=True,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
+        executable=executable,
         env=dict(os.environ, **{k: v for k, v in env.items() if v is not None}),
     )
     readline = process.stdout.readline if process.stdout else (lambda: b"")  # pragma: no branch

--- a/pgclone/run.py
+++ b/pgclone/run.py
@@ -39,7 +39,7 @@ def shell(
     if pipefail and _is_pipefail_supported():  # pragma: no cover
         cmd = f"set -o pipefail; {cmd}"
         # If requested and supported by the user's shell, enable pipefail and
-        # execute using that shell rather than the system default /bin/sh to 
+        # execute using that shell rather than the system default /bin/sh to
         # ensure the pipefail is supported.
         executable = os.environ.get("SHELL", "/bin/sh")
 


### PR DESCRIPTION
Right now we're checking to see if the user's shell supports pipefail, but we're not forcing `Popen` to use that shell. This PR fixes this issue when pipefail is needed.

Fixes: https://github.com/AmbitionEng/django-pgclone/issues/40